### PR TITLE
update to generate file for numpy array

### DIFF
--- a/src/ai/explore_generate_data.ipynb
+++ b/src/ai/explore_generate_data.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "# sudo apt-get install python-skimage\n",
     "import numpy as np\n",
     "from skimage.draw import polygon"
    ]

--- a/src/ai/generate_data.py
+++ b/src/ai/generate_data.py
@@ -11,9 +11,8 @@ def create_road(height=128, width=128, offset=0.0):
   if (math.fabs(offset) > left_edge):
     offset = math.copysign(left_edge, offset)
 
-  rows, columns = skimage.draw.polygon(  \
-    [0, height, height, 0],              \
-    [left_edge + offset, left_edge, right_edge, right_edge + offset])
+  rows, columns = skimage.draw.polygon(np.array([0, height, height, 0]),
+                                       np.array([left_edge + offset, left_edge, right_edge, right_edge + offset]))
   image[rows, columns] = 1
   image = image[:, :, np.newaxis]
   return image


### PR DESCRIPTION
im not sure what packages your build works on but in my latest build i could only get generate to work wrapped in numpy arrays because skimage was calling shape method. here's my pip env if it helps explains our different setups

```
pi@raspberrypi:~/nodebot_ai/src/ai $ pip freeze
Jinja2==2.8
MarkupSafe==0.23
Pillow==2.6.1
Pygments==2.1.3
RPi.GPIO==0.6.2
RTIMULib==7.2.1
argparse==1.2.1
backports-abc==0.4
backports.shutil-get-terminal-size==1.0.0
certifi==2016.8.2
chardet==2.3.0
colorama==0.3.2
configparser==3.5.0
decorator==4.0.10
entrypoints==0.2.2
funcsigs==1.0.2
functools32==3.2.3.post2
gpiozero==1.2.0
html5lib==0.999
ipykernel==4.3.1
ipython==5.0.0
ipython-genutils==0.1.0
ipywidgets==5.2.2
jsonschema==2.5.1
jupyter==1.0.0
jupyter-client==4.3.0
jupyter-console==5.0.0
jupyter-core==4.1.0
lxkeymap==0.1
matplotlib==1.4.2
mcpi==0.1.1
mistune==0.7.3
mock==2.0.0
nbconvert==4.2.0
nbformat==4.0.1
ndg-httpsclient==0.3.2
nose==1.3.4
notebook==4.2.2
numpy==1.8.2
pathlib2==2.1.0
pbr==1.10.0
pexpect==4.2.0
picamera==1.10
pickleshare==0.7.3
pifacecommon==4.2.1
pifacedigitalio==3.1.0
pigpio==1.30
prompt-toolkit==1.0.5
protobuf==3.0.0b2
ptyprocess==0.5.1
pyOpenSSL==0.13.1
pyasn1==0.1.7
pygame==1.9.2a0
pygobject==3.14.0
pyparsing==2.0.3
pyserial==2.6
python-apt==0.9.3.12
python-dateutil==2.2
pytz==2012rc0
pyzmq==15.3.0
qtconsole==4.2.1
requests==2.4.3
scikit-image==0.10.1
scipy==0.14.0
sense-hat==2.1.0
simplegeneric==0.8.1
singledispatch==3.4.0.3
six==1.10.0
spidev==3.0
tensorflow==0.9.0
terminado==0.6
tornado==4.4.1
traitlets==4.2.2
urllib3==1.9.1
wcwidth==0.1.7
wheel==0.24.0
widgetsnbextension==1.2.6
wsgiref==0.1.2
```
